### PR TITLE
[feat] user table setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/co/kr/metacoding/backendtest/user/User.java
+++ b/src/main/java/co/kr/metacoding/backendtest/user/User.java
@@ -1,0 +1,23 @@
+package co.kr.metacoding.backendtest.user;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Table(name = "user_tb")
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    private String name;
+
+    @Builder
+    public User(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/co/kr/metacoding/backendtest/user/UserController.java
+++ b/src/main/java/co/kr/metacoding/backendtest/user/UserController.java
@@ -1,0 +1,7 @@
+package co.kr.metacoding.backendtest.user;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+}

--- a/src/main/java/co/kr/metacoding/backendtest/user/UserRepository.java
+++ b/src/main/java/co/kr/metacoding/backendtest/user/UserRepository.java
@@ -1,0 +1,7 @@
+package co.kr.metacoding.backendtest.user;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserRepository {
+}

--- a/src/main/java/co/kr/metacoding/backendtest/user/UserRequest.java
+++ b/src/main/java/co/kr/metacoding/backendtest/user/UserRequest.java
@@ -1,0 +1,4 @@
+package co.kr.metacoding.backendtest.user;
+
+public class UserRequest {
+}

--- a/src/main/java/co/kr/metacoding/backendtest/user/UserResponse.java
+++ b/src/main/java/co/kr/metacoding/backendtest/user/UserResponse.java
@@ -1,0 +1,4 @@
+package co.kr.metacoding.backendtest.user;
+
+public class UserResponse {
+}

--- a/src/main/java/co/kr/metacoding/backendtest/user/UserService.java
+++ b/src/main/java/co/kr/metacoding/backendtest/user/UserService.java
@@ -1,0 +1,8 @@
+package co.kr.metacoding.backendtest.user;
+
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,22 @@
-spring.application.name=backendtest
+server.port=8080
+# vscode console highlight
+spring.output.ansi.enabled=always
+# utf-8
+server.servlet.encoding.charset=utf-8
+server.servlet.encoding.force=true
+# DB
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:test
+spring.datasource.username=pc
+spring.datasource.password=2024
+spring.h2.console.enabled=true
+# JPA table create or none
+spring.jpa.hibernate.ddl-auto=create
+# query log
+spring.jpa.show-sql=true
+# dummy data
+spring.sql.init.data-locations=classpath:db/data.sql
+# create dummy data  after ddl-auto create
+spring.jpa.defer-datasource-initialization=true
+# sql formatter
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -1,0 +1,4 @@
+insert into user_tb(name)
+values ('ssar');
+insert into user_tb(name)
+values ('cos');


### PR DESCRIPTION
### 1. 의존성 추가
`org.springframework.boot:spring-boot-starter-data-jpa`

> 이유 -> JPA(ORM)를 사용하기 위해 JPA 스타터 패키지를 설치